### PR TITLE
test: Update p2p_ibd_tx_relay.py to support minrelaytxfee as low as 1…

### DIFF
--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -28,8 +28,8 @@ from test_framework.p2p import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 
-MAX_FEE_FILTER = Decimal(9170997) / COIN
-NORMAL_FEE_FILTER = Decimal(100) / COIN
+MAX_FEE_FILTER = Decimal(9936506) / COIN
+NORMAL_FEE_FILTER = Decimal(10) / COIN
 
 
 class P2PIBDTxRelayTest(BitcoinTestFramework):
@@ -37,8 +37,8 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [
-            ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],
-            ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],
+            ["-minrelaytxfee={:.8f}".format(NORMAL_FEE_FILTER)],
+            ["-minrelaytxfee={:.8f}".format(NORMAL_FEE_FILTER)],
         ]
 
     def run_test(self):


### PR DESCRIPTION
### Summary

This PR updates `test/functional/p2p_ibd_txrelay.py` to align with the reduced `DEFAULT_MIN_RELAY_TX_FEE` of **100 sats/kvB**.

### Changes

- **Adjusted `NORMAL_FEE_FILTER`**  
  Scaled down from `Decimal(100) / COIN` to `Decimal(10) / COIN` to reflect the 10× reduction in the default min relay fee.

- **Updated `MAX_FEE_FILTER`**  
  Changed from `Decimal(9170997) / COIN` to `Decimal(9936506) / COIN` to match the output of `FeeFilterRounder` under the new lower default. This avoids timeout-related test failures due to mismatched filter expectations.
